### PR TITLE
Adds build support for Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ endif(COMMAND cmake_policy)
 
 SET (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  SET (GLUI_INCLUDE_DIR "/usr/local/include")
+ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
 # COMPILER SETTINGS (default: Release) and flags
 INCLUDE(CompilerSettings)
 

--- a/Library/Makefile
+++ b/Library/Makefile
@@ -5,6 +5,8 @@ ODECONFIG = --enable-shared --with-trimesh=none
 #(not recommended on Linux, may give reasonable performance on Windows)
 ODECONFIG += --enable-double-precision
 
+UNAME = $(shell uname)
+
 unpack-deps:
 	git clone https://github.com/krishauser/KrisLibrary
 	tar xvzf ode-0.11.1.tar.gz
@@ -19,8 +21,14 @@ dep-KrisLibrary:
 dep-tinyxml:
 	cd tinyxml; make lib
 
-dep-glui: 
+ifeq ($(UNAME), Darwin)
+dep-glui:
+	patch -N glui-2.36/src/makefile < glui-mac-osx.patch || true
 	cd glui-2.36/src; make
+else
+dep-glui:
+	cd glui-2.36/src; make
+endif
 
 dep-ode:
 	cd ode-0.11.1; X_EXTRA_LIBS=-lX11 ./configure $(ODECONFIG)

--- a/Library/glui-mac-osx.patch
+++ b/Library/glui-mac-osx.patch
@@ -1,0 +1,40 @@
+--- makefile	2015-08-30 23:44:26.000000000 -0400
++++ makefile.txt	2015-08-29 14:45:34.000000000 -0400
+@@ -15,14 +15,23 @@
+ CXX       = g++
+ CPPFLAGS += $(OPTS) -Wall -pedantic
+ endif
++ifeq ($(UNAME), Darwin)
++CXX       = g++
++CPPFLAGS += $(OPTS) -Wall -pedantic
++endif
+ 
+ #######################################
+ 
+ CPPFLAGS += -I./ -I./include
+ 
+ LIBGLUI = -L./lib -lglui
++ifeq ($(UNAME), Darwin)
++LIBGL   = -framework OpenGL 
++LIBS    = -L/opt/X11/lib -lXmu -lXext -lX11 -lXi -lm
++else
+ LIBGL   = -lGLU -lGL
+ LIBS    = -lXmu -lXext -lX11 -lXi -lm
++endif
+ 
+ # One of the following options only...
+ 
+@@ -35,8 +44,13 @@
+ # CPPFLAGS += -I/usr/X11R6/include -DGLUI_FREEGLUT
+ 
+ # (3) GLUT
++ifeq ($(UNAME), Darwin)
++LIBGLUT   = -L/usr/local/lib -lglut
++CPPFLAGS += -I/usr/local/include
++else
+ LIBGLUT   = -L/usr/X11R6/lib -lglut
+ CPPFLAGS += -I/usr/X11R6/include
++endif
+ 
+ #######################################
+ 

--- a/Modeling/Resources.cpp
+++ b/Modeling/Resources.cpp
@@ -6,13 +6,6 @@
 #include "IO/JSON.h"
 #include <sstream>
 
-template class BasicResource<Config>;
-template class BasicResource<Vector3>;
-template class BasicResource<Matrix3>;
-template class BasicResource<Matrix>;
-template class BasicResource<RigidTransform>;
-template class BasicResource<Hold>;
-template class BasicResource<Meshing::TriMesh>;
 template <> const char* BasicResource<Config>::className = "Config";
 template <> const char* BasicResource<Vector3>::className = "Vector3";
 template <> const char* BasicResource<Matrix3>::className = "Matrix3";
@@ -22,6 +15,13 @@ template <> const char* BasicResource<GeometricPrimitive3D>::className = "Geomet
 template <> const char* BasicResource<Hold>::className = "Hold";
 template <> const char* BasicResource<Meshing::TriMesh>::className = "TriMesh";
 template <> const char* BasicResource<Camera::Viewport>::className = "Viewport";
+template class BasicResource<Config>;
+template class BasicResource<Vector3>;
+template class BasicResource<Matrix3>;
+template class BasicResource<Matrix>;
+template class BasicResource<RigidTransform>;
+template class BasicResource<Hold>;
+template class BasicResource<Meshing::TriMesh>;
 
 
 void MakeRobotResourceLibrary(ResourceLibrary& library)

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -2,6 +2,7 @@ from distutils.core import setup,Extension
 import distutils.util
 import os
 import glob
+import sys
 
 #Parse settings from CMake
 includeDirs = """${KLAMPT_INCLUDE_DIRS}""".split(';')
@@ -45,6 +46,10 @@ rssourcefiles = commonfiles + ['robotsim.cpp','robotik.cpp','robotsim_wrap.cxx']
 mpsourcefiles = commonfiles + ['motionplanning.cpp','motionplanning_wrap.cxx']
 rfsourcefiles = commonfiles + ['rootfind.cpp','pyvectorfield.cpp','rootfind_wrap.cxx']
 
+extra_link_args = []
+if sys.platform == 'darwin':
+  extra_link_args = ['-framework', 'OpenGL']
+
 setup(name='Klampt',
       version='@KLAMPT_VERSION@',
       description="PyKlamp't",
@@ -57,6 +62,7 @@ setup(name='Klampt',
                              define_macros=commondefines,
                              library_dirs=libdirs,
                              libraries=libs,
+                             extra_link_args=extra_link_args,
                              language='c++'),
                    Extension('klampt._motionplanning',
                              [os.path.join('klampt/src',f) for f in mpsourcefiles],
@@ -64,6 +70,7 @@ setup(name='Klampt',
                              define_macros=commondefines,
                              library_dirs=libdirs,
                              libraries=libs,
+                             extra_link_args=extra_link_args,
                              language='c++'),
                    Extension('klampt._rootfind',
                              [os.path.join('klampt/src',f) for f in rfsourcefiles],
@@ -71,6 +78,7 @@ setup(name='Klampt',
                              define_macros=commondefines,
                              library_dirs=libdirs,
                              libraries=libs,
+                             extra_link_args=extra_link_args,
                              language='c++')],
       py_modules=['klampt.robotsim','klampt.motionplanning','klampt.rootfind'],
       packages=['klampt']


### PR DESCRIPTION
- Adds a patch file to fix GLUI build on Mac
- Modifies Makefile to automatically apply the patch file before
  building GLUI on Mac
- Swaps order of template specialization and instantiation in
  Resources.cpp
- Adds some Mac-specific linker flags to setup.py.in so that Python
  modules can find OpenGL
- Modify CMakeLists.txt on Mac to use homebrew version of GLUI