### PR TITLE
Simulation status tests

### DIFF
--- a/Python/klampt/sim/simulation.py
+++ b/Python/klampt/sim/simulation.py
@@ -158,8 +158,8 @@ class SimpleSimulator (Simulator):
 
     def getStatusString(self, status = -1):
         if status > 0:
-            return Simulator.getStatusString(status)
-        return Simulator.getStatusString(self.getStatus())
+            return Simulator.getStatusString(self, status)
+        return Simulator.getStatusString(self, self.getStatus())
 
     def beginLogging(self):
         self.logging = True

--- a/Python/klampt/sim/simulation.py
+++ b/Python/klampt/sim/simulation.py
@@ -156,6 +156,11 @@ class SimpleSimulator (Simulator):
     def getStatus(self):
         return self.worst_status
 
+    def getStatusString(self, status = -1):
+        if status > 0:
+            return Simulator.getStatusString(status)
+        return Simulator.getStatusString(self.getStatus())
+
     def beginLogging(self):
         self.logging = True
         self.logger = simlog.SimLogger(weakref.proxy(self),self.log_state_fn,self.log_contact_fn)

--- a/Python/klampt/src/robotsim.cpp
+++ b/Python/klampt/src/robotsim.cpp
@@ -2417,6 +2417,13 @@ void RobotModel::setJointLimits(const vector<double>& qmin,const vector<double>&
 {
   robot->qMin.copy(&qmin[0]);
   robot->qMax.copy(&qmax[0]);
+
+  for(unsigned int i = 0; i < robot->drivers.size(); ++i)
+  {
+      int link_index = robot->drivers[i].linkIndices[0];
+      robot->drivers[i].qmin = qmin[link_index];
+      robot->drivers[i].qmax = qmax[link_index];
+  }
 }
 
 void RobotModel::getVelocityLimits(vector<double>& vmax)
@@ -2428,6 +2435,13 @@ void RobotModel::getVelocityLimits(vector<double>& vmax)
 void RobotModel::setVelocityLimits(const vector<double>& vmax)
 {
   robot->velMax.copy(&vmax[0]);
+
+  for(unsigned int i = 0; i < robot->drivers.size(); ++i)
+  {
+      int link_index = robot->drivers[i].linkIndices[0];
+      robot->drivers[i].vmin = -vmax[link_index];
+      robot->drivers[i].vmax = vmax[link_index];
+  }
 }
 
 void RobotModel::getAccelerationLimits(vector<double>& amax)
@@ -2439,6 +2453,13 @@ void RobotModel::getAccelerationLimits(vector<double>& amax)
 void RobotModel::setAccelerationLimits(const vector<double>& amax)
 {
   robot->accMax.copy(&amax[0]);
+
+  for(unsigned int i = 0; i < robot->drivers.size(); ++i)
+  {
+      int link_index = robot->drivers[i].linkIndices[0];
+      robot->drivers[i].amin = -amax[link_index];
+      robot->drivers[i].amax = amax[link_index];
+  }
 }
 
 void RobotModel::getTorqueLimits(vector<double>& tmax)
@@ -2450,6 +2471,13 @@ void RobotModel::getTorqueLimits(vector<double>& tmax)
 void RobotModel::setTorqueLimits(const vector<double>& tmax)
 {
   robot->torqueMax.copy(&tmax[0]);
+
+  for(unsigned int i = 0; i < robot->drivers.size(); ++i)
+  {
+      int link_index = robot->drivers[i].linkIndices[0];
+      robot->drivers[i].tmin = -tmax[link_index];
+      robot->drivers[i].tmax = tmax[link_index];
+  }
 }
 
 void RobotModel::setDOFPosition(int i,double qi)

--- a/Simulation/ODESimulator.cpp
+++ b/Simulation/ODESimulator.cpp
@@ -1823,6 +1823,7 @@ bool ODESimulator::InstabilityCorrection()
       robots[i]->SetVelocities(dq*scale);
     }
   }
+  return corrected;
 }
 
 void ODESimulator::ClearContactFeedback()

--- a/tests/test_math_so3.py
+++ b/tests/test_math_so3.py
@@ -10,3 +10,6 @@ class so3Test(unittest.TestCase):
 
     def test_from_rpy(self):
         R = so3.from_rpy((0,0,0))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_robotsim.py
+++ b/tests/test_robotsim.py
@@ -14,4 +14,5 @@ class robotsimTest(unittest.TestCase):
         self.assertIsNotNone(pid_gains)
         self.assertTrue(len(pid_gains),3)
         
-
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_robotsim_getstatus.py
+++ b/tests/test_robotsim_getstatus.py
@@ -1,0 +1,37 @@
+import unittest
+from klampt.sim import *
+
+class robotsimTest(unittest.TestCase):
+
+    def setUp(self):
+        self.world = WorldModel()
+
+    def test_getStatus_unstable(self):
+        self.world.loadTerrain('data/terrains/plane.tri')
+        self.world.loadRobot('data/robots/swingup.rob')
+
+        sim = SimpleSimulator(self.world)
+        robot = self.world.robot(0)
+        sim.controller(0).setPIDCommand(robot.getConfig(), robot.getVelocity())
+        for i in range(10):
+            sim.simulate(0.01)
+        self.assertEqual(Simulator.STATUS_NORMAL, sim.getStatus(), sim.getStatusString())
+        sim.controller(0).setPIDGains([0.0], [0.0], [0.0])
+        robot.setTorqueLimits([1e6])
+        robot.setVelocityLimits([1e18])
+        robot.setAccelerationLimits([1e18])
+
+        sim.controller(0).setTorque([1e6])
+        sim.simulate(0.01)
+        self.assertEqual(Simulator.STATUS_UNSTABLE, sim.getStatus(), '%f is the final velocity for the joint, should be infinite'%sim.getActualVelocity(0)[0])
+        
+
+
+    def test_getStatus_adaptive_time_stepping(self):
+        pass
+
+    def test_getStatus_unreliable(self):
+        pass
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_robotsim_getstatus.py
+++ b/tests/test_robotsim_getstatus.py
@@ -7,7 +7,6 @@ class robotsimTest(unittest.TestCase):
         self.world = WorldModel()
 
     def test_getStatus_unstable(self):
-        self.world.loadTerrain('data/terrains/plane.tri')
         self.world.loadRobot('data/robots/swingup.rob')
 
         sim = SimpleSimulator(self.world)
@@ -23,15 +22,63 @@ class robotsimTest(unittest.TestCase):
 
         sim.controller(0).setTorque([1e6])
         sim.simulate(0.01)
+
         self.assertEqual(Simulator.STATUS_UNSTABLE, sim.getStatus(), '%f is the final velocity for the joint, should be infinite'%sim.getActualVelocity(0)[0])
 
+    def test_getStatus_status_is_matching(self):
+        self.world.loadTerrain('data/terrains/plane.tri')
+        self.world.loadRobot('data/robots/pr2gripper.rob')
+        self.world.loadRigidObject('data/objects/sphere_5cm.obj')
+        robot = self.world.robot(0)
+        sphere = self.world.rigidObject(0)
 
+        pt = robot.link(0).getParentTransform()
+        ct = sphere.getTransform()
+        sphere.setTransform(ct[0], [0.14, 0, 0.028])
+        robot.link(0).setParentTransform(pt[0], [.0, .0, 0.03])
+        robot.setConfig([0.0, 1.0491851842008302, 1.0491875315795012, -1.0491852558664032, 1.0491875316019472])
+        robot.setTorqueLimits([100, 100, 50, 100, 50])
+        sim = SimpleSimulator(self.world)
+        c = sim.controller(0)
+        c.setPIDCommand([1.0], [.0])
+        c.setPIDGains([15], [50], [0.1])
+        c.setPIDCommand([0], [0])
+        sim.simulate(0.1)
+
+        if sim.getStatus() == Simulator.STATUS_UNSTABLE:
+            self.assertEqual("unstable", sim.getStatusString())
+        else:
+            print "Warning, test test_getStatus_status_is_matching is useless as the simulation is now stable"
 
     def test_getStatus_adaptive_time_stepping(self):
-        pass
+        self.world.loadTerrain('data/terrains/plane.tri')
+        self.world.loadRigidObject('data/objects/sphere_5cm.obj')
+        sphere = self.world.rigidObject(0)
+        mass = sphere.getMass()
+        mass.setMass(100)
+        sphere.setMass(mass)
+
+        ct = sphere.getTransform()
+        sphere.setTransform(ct[0], [0, 0, 0.0263])
+        sim = SimpleSimulator(self.world)
+        sim.simulate(0.1)
+
+        self.assertEqual(Simulator.STATUS_ADAPTIVE_TIME_STEPPING, sim.getStatus())
 
     def test_getStatus_unreliable(self):
-        pass
+        self.world.loadTerrain('data/terrains/plane.tri')
+        self.world.loadRigidObject('data/objects/sphere_5cm.obj')
+        sphere = self.world.rigidObject(0)
+        mass = sphere.getMass()
+        mass.setMass(1000)
+        sphere.setMass(mass)
+
+        ct = sphere.getTransform()
+        sphere.setTransform(ct[0], [0, 0, 0.0263])
+        sim = SimpleSimulator(self.world)
+        sim.simulate(0.1)
+
+        self.assertEqual(Simulator.STATUS_CONTACT_UNRELIABLE, sim.getStatus())
         
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_robotsim_getstatus.py
+++ b/tests/test_robotsim_getstatus.py
@@ -24,7 +24,7 @@ class robotsimTest(unittest.TestCase):
         sim.controller(0).setTorque([1e6])
         sim.simulate(0.01)
         self.assertEqual(Simulator.STATUS_UNSTABLE, sim.getStatus(), '%f is the final velocity for the joint, should be infinite'%sim.getActualVelocity(0)[0])
-        
+
 
 
     def test_getStatus_adaptive_time_stepping(self):


### PR DESCRIPTION
Basic test set for Simulator.getStatus(), plus some bug fixes:
- 4edc286 fixes bug where `robot.setTorqueLimits()` and all other `robot.set*Limits()` would not automatically change corresponding values in the robot's drivers
- d961b4d fixes a bug where the simulation status was not detected reliably when the simulation became unstable (while it worked for adaptive time stepping, normla, and contact unreliable statuses)
- 12df03c fixes a bug where `SimpleSimulator` would correctly store the worst status of a series of simulation substeps, but the status given by `SimpleSimulator.getStatus()` did not match its description from `SimpleSimulator.getStatusString()` since the latter used the status string from the latest simulation substep