### PR TITLE
Fix rpy brittle

### DIFF
--- a/Python/klampt/math/so3.py
+++ b/Python/klampt/math/so3.py
@@ -77,7 +77,8 @@ def rpy(R):
     sign = lambda x: 1 if x > 0 else (-1 if x < 0 else 0)
 
     m = matrix(R)
-    b = -math.asin(m[2][0]) # m(2,0)=-sb
+    _sb = min(1.0, max(m[2][0],-1.0))
+    b = -math.asin(_sb) # m(2,0)=-sb
     cb = math.cos(b)
     if abs(cb) > 1e-7:
         ca = m[0][0]/cb   #m(0,0)=ca*cb
@@ -98,7 +99,8 @@ def rpy(R):
         #this reduces the degrees of freedom, so we can set c=0
         c = 0
         #m(0,1)=-sa
-        a = -math.asin(m[0][1]);
+        _sa = min(1.0, max(m[0][1],-1.0))
+        a = -math.asin(_sa);
         if sign(math.cos(a)) != sign(m[1][1]): #m(1,1)=ca
             a = math.pi - a;
     return c,b,a

--- a/tests/test_math_so3.py
+++ b/tests/test_math_so3.py
@@ -11,5 +11,12 @@ class so3Test(unittest.TestCase):
     def test_from_rpy(self):
         R = so3.from_rpy((0,0,0))
 
+    def test_rpy(self):
+        R = so3.from_quaternion((-4.32978e-17, -0.707107,4.32978e-17,0.707107))
+        r,p,y = so3.rpy(R)
+        self.assertAlmostEqual(r,0.0)
+        self.assertAlmostEqual(p,1.5707963267948966)
+        self.assertAlmostEqual(y,3.141592653589793)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I noticed the `klampt.math.so3.rpy` call can throw `math domain` errors because of its use of `asin` and `acos` in the implementation. This can be problematic in cases when frames are input from the outside, i.e. from text files. Precision errors on rotation matrices can cause the method to fail. The problem can be tackled in different ways (e.g. by using `atan2` instead of `asin` and `acos`) but this patch and PR just quickly solve the problem by forcing the input of those functions to be in their domain.

I would like also to point out a few differences with KDL, maybe this analysis would be of use to discuss and implement a more suitable fix. A gist where the issue is reproduced can be found [here](https://gist.github.com/arocchi/4207d70c02e460d8d32784a9f5b70c45)