### PR TITLE
Web devel

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,4 @@
+sudo docker rmi docker-klampt-old --force
+sudo docker tag docker-klampt docker-klampt-old
+sudo docker build -t docker-klampt .
+

--- a/build-test
+++ b/build-test
@@ -1,0 +1,4 @@
+sudo docker rmi docker-klampt-test-old --force
+sudo docker tag docker-klampt-test docker-klampt-test-old
+sudo docker build -t docker-klampt-test .
+

--- a/dockerconfigs/initialize.sh
+++ b/dockerconfigs/initialize.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# 
+# We will almost certainly will mount an external volume to hold 
+# the 'guest' user directory (so that their work persists between
+# container restarts). However, there is no guarantee that the
+# container user owns or can write to that external volume, so
+# make sure they own their home directory
+#
+chown -R klamptuser ~klamptuser ; chgrp -R users ~klamptuser
+
+#
+# set the password for the user 'klamptuser' based on environment variable. 
+#
+
+if [ ! -z $USERPASS ] 
+then
+  /bin/echo "klamptuser:$USERPASS" | /usr/sbin/chpasswd
+  unset USERPASS
+fi
+
+exit 0

--- a/dockerconfigs/supervisord-klampt.conf
+++ b/dockerconfigs/supervisord-klampt.conf
@@ -1,0 +1,23 @@
+[supervisord]
+nodaemon=true
+
+[program:initializestuff]
+priority=5
+directory=/
+command=/bin/bash /initialize.sh
+user=root
+autostart=true
+autorestart=false
+startsecs=0
+exitcodes=0
+stdout_logfile=/var/log/initialize.log
+stderr_logfile=/var/log/initialize.err
+
+[program:klamptserver]
+autostart=true
+directory=/Klampt
+command=/Klampt/WebServer
+user=klamptuser
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log

--- a/run-docker-klampt-server
+++ b/run-docker-klampt-server
@@ -1,0 +1,3 @@
+sudo docker run -d -p 0.0.0.0:1234:1234 \
+     -v /srv/persistent-data/src/Klampt/dockerlogs:/var/log/supervisor/ \
+    -e USERPASS=badpassword -i -t docker-klampt


### PR DESCRIPTION
updated Docker version
- based off Ubuntu 16.04
- includes supervisors to automatically run the WebServer
- WebServer run as klamptuser instead of root
- some initial code for assigning a password/token to the klamptuser at docker instance startup