### PR TITLE
double rendering in resouce ThumbnailPlugin

### DIFF
--- a/Python/klampt/io/resource.py
+++ b/Python/klampt/io/resource.py
@@ -375,7 +375,11 @@ class _ThumbnailPlugin(vis.VisualizationPlugin):
                 from PIL import Image
                 self.image = Image.frombuffer("RGBA", (view.w, view.h), screenshot, "raw", "RGBA", 0, 0)
             except ImportError:
-                self.image = screenshot
+                try:
+                    import Image
+                    self.image = Image.frombuffer("RGBA", (view.w, view.h), screenshot, "raw", "RGBA", 0, 0)
+                except ImportError:
+                    self.image = screenshot
             self.done = True
         return True
 
@@ -435,8 +439,17 @@ def thumbnail(value,size,type='auto',world=None,frame=None):
     vis.show(False)
     vis.setWindow(old_window)
     if (vp.w,vp.h) != size and plugin.image.__class__.__name__=='Image':
-        from PIL import Image
-        plugin.image.thumbnail(size,Image.ANTIALIAS)
+        try:
+            from PIL import Image
+            plugin.image.thumbnail(size,Image.ANTIALIAS)
+        except ImportError:
+            try:
+                import Image
+                plugin.image.thumbnail(size,Image.ANTIALIAS)
+            except ImportError:
+                # if this happens then
+                # plugin.image is just a raw RGBA memory buffer
+                pass
     return plugin.image
 
 def console_edit(name,value,type,description=None,world=None,frame=None):

--- a/Python/klampt/io/resource.py
+++ b/Python/klampt/io/resource.py
@@ -360,19 +360,19 @@ class _ThumbnailPlugin(vis.VisualizationPlugin):
         vis.VisualizationPlugin.__init__(self)
         self.world = world
         self.done = False
-        self.rendered = False
+        self.rendered = 0
         self.image = None
     def display(self):
-        self.rendered = True
+        self.rendered += 1
         vis.VisualizationPlugin.display(self)
     def idle(self):
         vis.VisualizationPlugin.idle(self)
-        if self.rendered and not self.done:
+        if self.rendered >= 2 and not self.done:
             from OpenGL.GL import glReadPixels,GL_RGBA,GL_UNSIGNED_BYTE
             view = self.window.program.view
             screenshot = glReadPixels( view.x, view.y, view.w, view.h, GL_RGBA, GL_UNSIGNED_BYTE)
             try:
-                import Image
+                from PIL import Image
                 self.image = Image.frombuffer("RGBA", (view.w, view.h), screenshot, "raw", "RGBA", 0, 0)
             except ImportError:
                 self.image = screenshot
@@ -428,14 +428,14 @@ def thumbnail(value,size,type='auto',world=None,frame=None):
     plugin.autoFitCamera()
     vis.setPlugin(plugin)
     vis.show()
-    plugin.rendered = False
+    plugin.rendered = 0
     while not plugin.done:
         time.sleep(0.1)
     vis.setPlugin(None)
     vis.show(False)
     vis.setWindow(old_window)
     if (vp.w,vp.h) != size and plugin.image.__class__.__name__=='Image':
-        import Image
+        from PIL import Image
         plugin.image.thumbnail(size,Image.ANTIALIAS)
     return plugin.image
 
@@ -626,5 +626,4 @@ def edit(name,value,type='auto',description=None,editor='visual',world=None,refe
             raise RuntimeError("Visual editing of objects of type "+type+" not supported yet")
     else:
         raise ValueError("Invalid value for argument 'editor', must be either 'visual' or 'console'")
-
 

--- a/Python/klampt/vis/glprogram.py
+++ b/Python/klampt/vis/glprogram.py
@@ -302,10 +302,10 @@ class GLProgram:
     def save_screen(self,fn,multithreaded=True):
         """Saves a screenshot"""
         try:
-            import Image
+            from PIL import Image
         except ImportError:
             try:
-                from PIL import Image
+                import Image
             except ImportError:
                 print "Cannot save screens to disk, the Python Imaging Library is not installed"
                 return

--- a/Python/klampt/vis/glprogram.py
+++ b/Python/klampt/vis/glprogram.py
@@ -304,8 +304,11 @@ class GLProgram:
         try:
             import Image
         except ImportError:
-            print "Cannot save screens to disk, the Python Imaging Library is not installed"
-            return
+            try:
+                from PIL import Image
+            except ImportError:
+                print "Cannot save screens to disk, the Python Imaging Library is not installed"
+                return
         if hasattr(self.window,'makeCurrent'):
             self.window.makeCurrent()
         glReadBuffer(GL_FRONT);


### PR DESCRIPTION
1. resolved double rendering issue in `Python/klampt/io/resource.ThumbnailPlugin`
1. added `from PIL import Image` when `import Image` fails