### PR TITLE
Small typo in math.se3

### DIFF
--- a/Python/klampt/math/se3.py
+++ b/Python/klampt/math/se3.py
@@ -53,7 +53,7 @@ def rotation(T):
 
 def from_rotation(mat):
     """Returns a transformation T corresponding to the 3x3 rotation matrix mat"""
-    R = so3.from_matrix(R)
+    R = so3.from_matrix(mat)
     return (R,[0.,0.,0.])
 
 def translation(T):


### PR DESCRIPTION
In function se3.from_rotation the input "mat" was not being used to create the rotation matrix, but its own output "R". This typo is now fixed.