### PR TITLE
Fix missing color feature when converting point clouds

### DIFF
--- a/Python/klampt/io/open3d_convert.py
+++ b/Python/klampt/io/open3d_convert.py
@@ -8,7 +8,6 @@ It can be installed using pip as follows:
 """
 
 import open3d
-import numpy as np
 from klampt import PointCloud,TriangleMesh,VolumeGrid,Geometry3D
 
 def to_open3d(obj):
@@ -78,6 +77,7 @@ def from_open3d(obj):
     """
     if isinstance(obj,open3d.geometry.PointCloud):
         pc = PointCloud()
+        import numpy as np
         for p in obj.points:
             pc.vertices.append(p[0])
             pc.vertices.append(p[1])

--- a/Python/klampt/io/open3d_convert.py
+++ b/Python/klampt/io/open3d_convert.py
@@ -8,6 +8,7 @@ It can be installed using pip as follows:
 """
 
 import open3d
+import numpy as np
 from klampt import PointCloud,TriangleMesh,VolumeGrid,Geometry3D
 
 def to_open3d(obj):
@@ -81,7 +82,14 @@ def from_open3d(obj):
             pc.vertices.append(p[0])
             pc.vertices.append(p[1])
             pc.vertices.append(p[2])
-        #TODO: other properties
+        if obj.has_colors():
+            pc.addProperty('rgb')
+            colors = np.array(obj.colors)
+            r = (colors[:,0]*255.0).astype(np.uint32)
+            g = (colors[:,1]*255.0).astype(np.uint32)
+            b = (colors[:,2]*255.0).astype(np.uint32)
+            rgb = np.bitwise_or.reduce((np.left_shift(r,16),np.left_shift(g,8),b))
+            pc.setProperties(pc.numProperties()-1,rgb.tolist())
         return pc
     elif isinstance(obj,open3d.geometry.TriangleMesh):
         m = TriangleMesh()


### PR DESCRIPTION
Hi, as discussed in Monday meeting, I have added color feature to point cloud object in python bindings.

There may still be additional changes requested:

- [ ] Apply the same patch to python2 bindings if we still want to provide support for older python
- [x] Update colorize function documentation https://github.com/krishauser/Klampt/blob/7e34b5161958b53de51e4acb6cf1b642f73a6437/Python/klampt/vis/colorize.py#L52
 The code in the function actually adds 'rgb' or 'rgba' property instead of 'color' attribute. Not using exact property name caused some confusion to developer.

For the slow rendering of 640x480 point cloud problem, we need to try on a more powerful gpu computer.

Best,