### PR TITLE
Primitive sphere mass bug

### DIFF
--- a/Python/klampt/model/create/primitives.py
+++ b/Python/klampt/model/create/primitives.py
@@ -108,7 +108,7 @@ def sphere(radius,center=None,R=None,t=None,world=None,name=None,mass=float('inf
         bmass = Mass()
         bmass.setMass(mass)
         bmass.setCom(center)
-        bmass.setInertia([0.4*mass*radius**2])
+        bmass.setInertia([0.4*mass*radius**2]*3)
         robj = world.makeRigidObject(name)
         robj.geometry().set(geom)
         robj.setMass(bmass)

--- a/Python/python2_version/klampt/model/create/primitives.py
+++ b/Python/python2_version/klampt/model/create/primitives.py
@@ -101,7 +101,7 @@ def sphere(radius,center=None,R=None,t=None,world=None,name=None,mass=float('inf
         bmass = Mass()
         bmass.setMass(mass)
         bmass.setCom(center)
-        bmass.setInertia([0.4*mass*radius**2])
+        bmass.setInertia([0.4*mass*radius**2]*3)
         robj = world.makeRigidObject(name)
         robj.geometry().set(geom)
         robj.setMass(bmass)


### PR DESCRIPTION
When creating a RigidObject primitive sphere, give three element
inertia matrix instead of one element.