### PR TITLE
Fix memory leak when calling getPlanJSONString

### DIFF
--- a/Python/klampt/src/motionplanning.i
+++ b/Python/klampt/src/motionplanning.i
@@ -7,6 +7,7 @@
 %}
 
 %include "std_vector.i"
+%include "std_string.i"
 	
 namespace std {
    %template(doubleVector) vector<double>;


### PR DESCRIPTION
In motionplan homework there is a memory leak issue "swig/python detected a memory leak of type 'std::string *', no destructor found." This is due to the missing import of std::string class in swig interface. The bug showed up because the return type of getPlanJSONString is not properly defined.

This patch is applied to devel branch instead of master because there is a recent upgrade on swig from 3.x to 4.x
After applying this patch we still need to run Makefile in Python/klampt/src to update all the automatically generated wrappers, before we recompile for Python.

