### PR TITLE
Dockerfile and documentation improvement for docker manual

### DIFF
--- a/Cpp/docs/Tutorials/Install-Docker.md
+++ b/Cpp/docs/Tutorials/Install-Docker.md
@@ -63,6 +63,8 @@ You should be able to run a Jupyter notebook containing Klamp't, which should lo
 
 ## Running the X11 Image
 
+On Linux distributions:
+
 Once you've installed Docker, setup X forwarding `$ xhost +` before run the container.
 
 You may also need to build the container by `$ docker build -t klampt .`.
@@ -70,7 +72,7 @@ You may also need to build the container by `$ docker build -t klampt .`.
 On RPM Linux (like Red Hat or Fedora), use:
 
 ```sh
-$ docker run -it -e DISPLAY=unix$DISPLAY -w /etc/Klampt --name klampt -v /tmp/.X11-unix:/tmp/.X11-unix stevekuznetsov/klampt:latest
+$ docker run -it -e DISPLAY=unix$DISPLAY -w /etc/Klampt --name klampt -v /tmp/.X11-unix:/tmp/.X11-unix klampt
 ```
 
 On Debian Linux (like Ubuntu), use:
@@ -79,11 +81,11 @@ On Debian Linux (like Ubuntu), use:
 $ docker run -it -e DISPLAY=$DISPLAY -w /etc/Klampt --name klampt -v /tmp/.X11-unix:/tmp/.X11-unix --net=host klampt
 ```
 
-On Windows (Outdated), you need to get [`Xming`](http://sourceforge.net/projects/xming/) and install it, then run:
+On Windows, you need to get [`Xming`](http://sourceforge.net/projects/xming/) and install it, then run:
 
 ```
 > Xming.exe :0 -multiwindow -clipboard -ac
-> docker run -it -e DISPLAY=192.168.99.1:0 -w /etc/Klampt --name klampt stevekuznetsov/klampt:latest
+> docker run -it -e DISPLAY=host.docker.internal:0.0 -w /etc/Klampt --name klampt klampt
 ```
 
 On Mac (Outdated), run the following in iTerm.app or Terminal.app:
@@ -97,7 +99,7 @@ $ socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"
 Then, in whatever terminal you like (can be the same as above), but *not* in the Docker terminal, run:
 
 ```sh
-$ docker run -it -e DISPLAY=192.168.99.1:0 -w /etc/Klampt --name klampt stevekuznetsov/klampt:latest
+$ docker run -it -e DISPLAY=host.docker.internal:0 -w /etc/Klampt --name klampt klampt
 ```
 
 Finally, if `XQuartz` did not start automatically, start it:
@@ -131,14 +133,14 @@ $ python3
 
 After that, you should be able to see an X window popping up in your host machine.
 
-#### Using Klamp't 
+### Using Klamp't 
 
 Once you've created your own scripts that you wish to run, save them in some directory on your host, and amend the `docker run` command used above to include `-v /path/to/your/data:/home/Klampt/data`. For instance, the RPM Linux `run` command, if there is data at `/home/myuser/klamptdata`, would look like:
 
 ```sh
 docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --name klampt \
 	-v /home/myuser/klamptdata:/home/Klampt/data \ # shares data with the container
-	stevekuznetsov/klampt:latest
+	klampt
 ```
 
 Then, use the internal tools inside of the container (i.e. `SimTest`, `RobotTest`, etc.) on your files. They will be found in `/home/Klampt/data`. 

--- a/Cpp/docs/Tutorials/Install-Docker.md
+++ b/Cpp/docs/Tutorials/Install-Docker.md
@@ -11,34 +11,26 @@ SAVE ANY FILES YOU WISH TO KEEP IN YOUR "WORK" FOLDER.  ALL OTHER FILES WILL NOT
 
 ## Installing Docker
 
-### Unix
+### *nix
 
 1. Follow the instructions on Docker's website to install Docker for Linux
-   https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository
-2. Follow the instructions on Docker's website to install Docker-compose for Linux
-   https://docs.docker.com/compose/install/#install-compose
+   https://docs.docker.com/engine/install/ubuntu/
+2. If you wish to access GPU inside docker container, follow the instructions on Nvidia's website to install nvidia-docker for Linux
+   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide
+   
+   **Note:** Currently only Linux supports accessing GPU inside Docker, all other platforms are not supported
 
 ### Windows
 
-1. Register a Docker ID. You may need one to download Docker.
+1. Follow the instructions on Docker's website to install Docker Desktop on Windows
 
-2. Follow the instructions on Docker's website to install Docker on Windows
-
-    a. If you have Windows 10 Pro, Enterprise, or Education, lookup instructions for Downloading and Installing Docker
-
-    b. If you have Windows 10 Home or a different edition not mentioned above, download Docker Toolbox
+    a. Go to https://docs.docker.com/docker-for-windows/install/
 
 ### Mac
 
-1. Register a Docker ID - you need one to download Docker from the Docker store for Mac
+1. Follow the instructions on Docker's website to install Docker Desktop on Mac (both Intel and Apple chip)
 
-2. Follow the instructions on Docker's website to install Docker on Mac
-
-    a. If you have a Mac from after 2010, you should be able to just install Docker
-
-    b. If you have a Mac from earlier, you may need to install Docker-toolbox. Read the instructions for doing so
-
-
+    a. Go to https://docs.docker.com/docker-for-windows/install/
 
 ## Running the Jupyter Notebook image (recommended)
 
@@ -71,7 +63,9 @@ You should be able to run a Jupyter notebook containing Klamp't, which should lo
 
 ## Running the X11 Image (out of date)
 
-Once you've installed Docker, run the container. 
+Once you've installed Docker, setup X forwarding `$ xhost +` before run the container.
+
+You may also need to build the container by `$ docker build -t klampt .`.
 
 On RPM Linux (like Red Hat or Fedora), use:
 
@@ -82,17 +76,17 @@ $ docker run -it -e DISPLAY=unix$DISPLAY -w /etc/Klampt --name klampt -v /tmp/.X
 On Debian Linux (like Ubuntu), use:
 
 ```sh
-$ docker run -it -e DISPLAY=unix$DISPLAY -w /etc/Klampt --name klampt -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/home/Klampt/.Xauthority -e XAUTHORITY=/home/Klampt/.Xauthority --net=host stevekuznetsov/klampt:latest
+$ docker run -it -e DISPLAY=$DISPLAY -w /etc/Klampt --name klampt -v /tmp/.X11-unix:/tmp/.X11-unix --net=host klampt
 ```
 
-On Windows, you need to get [`Xming`](http://sourceforge.net/projects/xming/) and install it, then run:
+On Windows (Outdated), you need to get [`Xming`](http://sourceforge.net/projects/xming/) and install it, then run:
 
 ```
 > Xming.exe :0 -multiwindow -clipboard -ac
 > docker run -it -e DISPLAY=192.168.99.1:0 -w /etc/Klampt --name klampt stevekuznetsov/klampt:latest
 ```
 
-On Mac, run the following in iTerm.app or Terminal.app:
+On Mac (Outdated), run the following in iTerm.app or Terminal.app:
 
 ```sh
 $ brew install socat
@@ -117,14 +111,25 @@ The parts of the `docker run` command are explained below. Not all parts apply t
   Command                                       | Description                                     | Operating Systems |
 | --------------------------------------------- | ----------------------------------------------- | ----------------- |
 `-it`                                           | keeps the container active                      | all               |
-`-e DISPLAY=unix$DISPLAY`                       | connects displays                               | all               |
+`-e DISPLAY=$DISPLAY`                       | connects displays                               | all               |
 `--name klampt`                                 | names the container                             | all               | 
 `-w /etc/Klampt`                                | sets working directory                          | all               |
 `-v /tmp/.X11-unix:/tmp/.X11-unix`              | mounts the x11 socket                           | all Linux         |
-`-v $HOME/.Xauthority:/home/Klampt/.Xauthority` | mounts the Xauthority files                     | Debian Linux      |
-`-e XAUTHORITY=/home/Klampt/.Xauthority`        | allows the container to connect to the X server | Debian Linux      |
 `--net=host`                                    | places container inside host's network stack    | Debian Linux      |
-`stevekuznetsov/klampt:latest`                  | decides which image to run                      | all               |
+`klampt`                  | decides which image to run                      | all               |
+
+## Test your docker visualization works correctly
+
+You can test that your GUI works by typing the following commands in the interactive shell of container.
+
+```
+$ python3
+>>> import klampt.vis
+>>> klampt.vis.init("PyQt5")
+>>> klampt.vis.debug()
+```
+
+After that, you should be able to see an X window popping up in your host machine.
 
 #### Using Klamp't 
 

--- a/Cpp/docs/Tutorials/Install-Docker.md
+++ b/Cpp/docs/Tutorials/Install-Docker.md
@@ -61,7 +61,7 @@ You should be able to run a Jupyter notebook containing Klamp't, which should lo
 
 ![Jupyter image](../../../Python/docs/source/_static/images/jupyter.png)
 
-## Running the X11 Image (out of date)
+## Running the X11 Image
 
 Once you've installed Docker, setup X forwarding `$ xhost +` before run the container.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ MAINTAINER Steve Kuznetsov <skuznets@redhat.com>
 # Install dependencies
 RUN apt-get update
 
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+
 RUN apt-get -y install freeglut3-dev qt5-default
 
 RUN apt-get -y install python3-dev python3-pip
 
-RUN pip3 install Klampt
+RUN pip3 install PyOpenGL PyQt5 Klampt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:20.04
 
 # This image contains Klamp't: Kris' Locomotion and Manipulation Planning Toolbox
 # This image utilizes X11 in order to allow users to interact with the GUI.
@@ -7,43 +7,10 @@ FROM ubuntu:15.04
 MAINTAINER Steve Kuznetsov <skuznets@redhat.com>
 
 # Install dependencies
-RUN apt-get update && \
-	apt-get -y install g++ \
-	 cmake \
-	 git \
-	 freeglut3 \
-	 freeglut3-dev \
-	 libglpk-dev \
-	 python-dev \
-	 python-opengl \
-	 libxmu-dev \
-	 libxi-dev \
-	 libqt4-dev \
-	 libassimp-dev \
-	 ffmpeg && \
-	apt-get clean
+RUN apt-get update
 
-# Copy Klamp't files
-RUN mkdir /etc/Klampt
-COPY CMakeLists.txt /etc/Klampt/CMakeLists.txt
-COPY CMakeModules /etc/Klampt/CMakeModules/
-COPY Cpp /etc/Klampt/Cpp
-COPY data /etc/Klampt/data/
-COPY LICENSE /etc/Klampt/LICENSE
-COPY Python /etc/Klampt/Python/
+RUN apt-get -y install freeglut3-dev qt5-default
 
-# Install Klamp't dependencies
-RUN cd /etc/Klampt/Cpp/Dependencies && \
-	make unpack-deps && \
-	make deps && \
-	echo "/etc/Klampt/Cpp/Dependencies/ode-0.14/ode/src/.libs/" >> /etc/ld.so.conf && \
-	ldconfig
+RUN apt-get -y install python3-dev python3-pip
 
-# Install Klamp't
-RUN cd /etc/Klampt && \
-	cmake . && \
-	make Klampt && \
-	make apps && \ 
-	make python && \
-	make python-install
-
+RUN pip3 install Klampt


### PR DESCRIPTION
Hi,

As a byproduct of recent TRINA changes to use docker based image that can make the setup process easier and more robust to system dependency changes, we have also updated the document Linux docker version of Klampt.

The setups for X window with OpenGL and Qt are now up-to-date with latest docker version on Ubuntu 20.04.

