### PR TITLE
Typo in point cloud construction

### DIFF
--- a/Python/klampt/model/sensing.py
+++ b/Python/klampt/model/sensing.py
@@ -366,7 +366,7 @@ def image_to_points(depth,color,xfov,yfov=None,depth_scale=None,depth_range=None
 
     if points_format == 'numpy':
         if color_format is not None:
-            pts = np.concatenate((pts,color),2)
+            pts = np.concatenate((pts,color),1)
         return pts
     elif points_format == 'PointCloud' or points_format == 'Geometry3D':
         res = PointCloud()


### PR DESCRIPTION
Concatenate points and colors along dim 1 instead of 2
(already been reshaped to (w*h, 3)).