### PR TITLE
Removed q0 as argument throwing an error

### DIFF
--- a/Python/klampt/plan/kinetrajopt/utils.py
+++ b/Python/klampt/plan/kinetrajopt/utils.py
@@ -145,7 +145,7 @@ class MaskedRobot(object):
         return self.robot.link(int(self.index[num]))
 
     def link(self, num):
-        return self.robot.link(num)
+        return self.robot.link(int(num))
 
 
 class MaskedTerrain(object):

--- a/Python/klampt/plan/robotplanning.py
+++ b/Python/klampt/plan/robotplanning.py
@@ -323,7 +323,7 @@ def planToSet(world,robot,target,
     if hasattr(space,'lift'):  #the planning takes place in a space of lower dimension than #links
         plan = EmbeddedMotionPlan(space,q0,**planOptions)
     else:
-        plan = MotionPlan(space,q0,**planOptions)
+        plan = MotionPlan(space,**planOptions)
 
     #convert target to a (test,sample) pair if it's a cspace
     if isinstance(target,CSpace):


### PR DESCRIPTION
This pull request fixes issue #123 by removing the erroneous `q0` argument from the MotionPlan constructor call.

Tested after making the change and re-compiling and it indeed fixes the issue when calling `robotplanning.planToCartesion` and `planToSet`.