### PR TITLE
Fix read colors for point cloud using from_open3d

### DIFF
--- a/Python/klampt/io/open3d_convert.py
+++ b/Python/klampt/io/open3d_convert.py
@@ -79,7 +79,7 @@ def from_open3d(obj):
         pc = PointCloud()
         pc.setPoints(np.asarray(obj.points))
         if obj.has_colors():
-            geometry.point_cloud_set_colors(pc,np.asarray(obj.colors).T,('r','g','b'),'rgb')
+            geometry.point_cloud_set_colors(pc,np.asarray(obj.colors),('r','g','b'),'rgb')
         #TODO: other properties
         return pc
     elif isinstance(obj,open3d.geometry.TriangleMesh):


### PR DESCRIPTION
Fix on `klampt.io.open3d_convert.py`, https://github.com/krishauser/Klampt/blob/dbaf38ca290a36fba9a8f4f9b6a49fda689f6585/Python/klampt/io/open3d_convert.py#L82C12-L82C12

Open3D `0.17.0` returns (Nx3) array when using `np.array(pcd.colors)`, so there is no need to perform the transpose.