### PR TITLE
Add missing try-catch to cartesianPosition getter command

### DIFF
--- a/Python/klampt/control/robotinterfaceutils.py
+++ b/Python/klampt/control/robotinterfaceutils.py
@@ -5169,7 +5169,11 @@ class RobotInterfaceEmulator:
             self.klamptModel.setConfig(self.klamptModel.configFromDrivers(q))
             return self.klamptModel.link(indices).getTransform()
         try:
-            c = self.cartesianInterfaces[tuple(indices)]
+            try:
+                c = self.cartesianInterfaces[tuple(indices)]
+            except KeyError:
+                c = _CartesianEmulatorData(self.klamptModel,indices)
+                self.cartesianInterfaces[tuple(indices)] = c
             return c.cartesianPosition(q,frame)
         except KeyError:
             raise ValueError("Invalid Cartesian index set for emulator: no command currently set")


### PR DESCRIPTION
To potentially fix the RobotInterfaceCompleter, which was not completing the interface for Cartesian Control.