### PR TITLE
Temporarily cap the numpy version

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "numpy"
+    "numpy<2"
 ]
 build-backend = "setuptools.build_meta"

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,3 +1,3 @@
 # klampt Python package dependencies
 PyOpenGL
-numpy
+numpy<2

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -165,7 +165,7 @@ setup(name='Klampt',
       ],
       install_requires=[
         'PyOpenGL',
-        'numpy>='+numpy_oldest_acceptable_version
+        'numpy>='+numpy_oldest_acceptable_version+',<2'
       ],
      )
 


### PR DESCRIPTION
<img width="625" alt="Screenshot 2024-06-17 at 9 55 47 AM" src="https://github.com/krishauser/Klampt/assets/38666763/576f3fa9-4200-40d7-9629-962726d0c33d">

We need to figure out some way to support numpy2 in the future.