### PR TITLE
Just executes first milestone running execute trajectory

### DIFF
--- a/Python/klampt/model/calibrate.py
+++ b/Python/klampt/model/calibrate.py
@@ -406,7 +406,7 @@ class RobotExtrinsicCalibration:
         for i in range(len(traj.milestones)):
             print("Moving to milestone",i)
             controller.beginStep()
-            controller.moveToPosition(self.robot.configToDrivers(traj.milestones[0]),speed)
+            controller.moveToPosition(self.robot.configToDrivers(traj.milestones[i]),speed)
             controller.endStep()
             wait_for_move()
 


### PR DESCRIPTION
Hi Prof. Hauser,

According to calibrate.py, I noticed a thing in RobotExtrinsicCalibration that when the trajectory, including multiple milestones, are being executed, only first milestone goes under operation. 

Sincerely,
Parsa Riazi Bakhshayesh